### PR TITLE
refactor: rename packages from test names to prod. ready names

### DIFF
--- a/src/main/java/com/epam/triangful/TriangFulApplication.java
+++ b/src/main/java/com/epam/triangful/TriangFulApplication.java
@@ -1,4 +1,4 @@
-package com.labs.restservice;
+package com.epam.triangful;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -7,10 +7,10 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
-public class RestServiceApplication {
+public class TriangFulApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(RestServiceApplication.class, args);
+        SpringApplication.run(TriangFulApplication.class, args);
     }
 
 }

--- a/src/main/java/com/epam/triangful/cache/TriangleCacheService.java
+++ b/src/main/java/com/epam/triangful/cache/TriangleCacheService.java
@@ -1,7 +1,7 @@
-package com.labs.restservice.cache;
+package com.epam.triangful.cache;
 
-import com.labs.restservice.calculations.CalculationResults;
-import com.labs.restservice.triangle.Triangle;
+import com.epam.triangful.calculations.CalculationResults;
+import com.epam.triangful.triangle.Triangle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/epam/triangful/calculations/CalculationResults.java
+++ b/src/main/java/com/epam/triangful/calculations/CalculationResults.java
@@ -1,4 +1,4 @@
-package com.labs.restservice.calculations;
+package com.epam.triangful.calculations;
 
 public class CalculationResults {
     private long perimeter;

--- a/src/main/java/com/epam/triangful/calculations/CalculationService.java
+++ b/src/main/java/com/epam/triangful/calculations/CalculationService.java
@@ -1,7 +1,7 @@
-package com.labs.restservice.calculations;
+package com.epam.triangful.calculations;
 
-import com.labs.restservice.exception.InternalException.InternalArithmeticException;
-import com.labs.restservice.triangle.Triangle;
+import com.epam.triangful.exception.InternalException.InternalArithmeticException;
+import com.epam.triangful.triangle.Triangle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/epam/triangful/concurrency/ServiceAccessManager.java
+++ b/src/main/java/com/epam/triangful/concurrency/ServiceAccessManager.java
@@ -1,4 +1,4 @@
-package com.labs.restservice.concurrency;
+package com.epam.triangful.concurrency;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/com/epam/triangful/exception/ApiException/ApiException.java
+++ b/src/main/java/com/epam/triangful/exception/ApiException/ApiException.java
@@ -1,4 +1,4 @@
-package com.labs.restservice.exception.ApiException;
+package com.epam.triangful.exception.ApiException;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/epam/triangful/exception/ApiException/ApiExceptionHandler.java
+++ b/src/main/java/com/epam/triangful/exception/ApiException/ApiExceptionHandler.java
@@ -1,6 +1,6 @@
-package com.labs.restservice.exception.ApiException;
+package com.epam.triangful.exception.ApiException;
 
-import com.labs.restservice.calculations.CalculationService;
+import com.epam.triangful.calculations.CalculationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/epam/triangful/exception/ApiException/ApiRequestException.java
+++ b/src/main/java/com/epam/triangful/exception/ApiException/ApiRequestException.java
@@ -1,4 +1,4 @@
-package com.labs.restservice.exception.ApiException;
+package com.epam.triangful.exception.ApiException;
 
 public class ApiRequestException extends RuntimeException {
 

--- a/src/main/java/com/epam/triangful/exception/InternalException/InternalArithmeticException.java
+++ b/src/main/java/com/epam/triangful/exception/InternalException/InternalArithmeticException.java
@@ -1,4 +1,4 @@
-package com.labs.restservice.exception.InternalException;
+package com.epam.triangful.exception.InternalException;
 
 public class InternalArithmeticException extends ArithmeticException {
 

--- a/src/main/java/com/epam/triangful/exception/InternalException/InternalException.java
+++ b/src/main/java/com/epam/triangful/exception/InternalException/InternalException.java
@@ -1,4 +1,4 @@
-package com.labs.restservice.exception.InternalException;
+package com.epam.triangful.exception.InternalException;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import org.springframework.http.HttpStatus;
 import java.time.LocalDateTime;

--- a/src/main/java/com/epam/triangful/exception/InternalException/InternalExceptionHandler.java
+++ b/src/main/java/com/epam/triangful/exception/InternalException/InternalExceptionHandler.java
@@ -1,5 +1,5 @@
-package com.labs.restservice.exception.InternalException;
-import com.labs.restservice.calculations.CalculationService;
+package com.epam.triangful.exception.InternalException;
+import com.epam.triangful.calculations.CalculationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/epam/triangful/triangle/Triangle.java
+++ b/src/main/java/com/epam/triangful/triangle/Triangle.java
@@ -1,6 +1,6 @@
-package com.labs.restservice.triangle;
+package com.epam.triangful.triangle;
 
-import com.labs.restservice.exception.ApiException.ApiRequestException;
+import com.epam.triangful.exception.ApiException.ApiRequestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/epam/triangful/triangle/TriangleController.java
+++ b/src/main/java/com/epam/triangful/triangle/TriangleController.java
@@ -1,20 +1,16 @@
-package com.labs.restservice.triangle;
+package com.epam.triangful.triangle;
 
-import com.labs.restservice.cache.TriangleCacheService;
-import com.labs.restservice.calculations.CalculationResults;
-import com.labs.restservice.calculations.CalculationService;
-import com.labs.restservice.concurrency.ServiceAccessManager;
-import com.labs.restservice.exception.ApiException.ApiRequestException;
+import com.epam.triangful.calculations.CalculationResults;
+import com.epam.triangful.calculations.CalculationService;
+import com.epam.triangful.concurrency.ServiceAccessManager;
+import com.epam.triangful.exception.ApiException.ApiRequestException;
+import com.epam.triangful.cache.TriangleCacheService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
-import java.util.Optional;
 
 @RestController
 public class TriangleController {

--- a/src/test/java/com/epam/triangful/TriangleCalculationTest.java
+++ b/src/test/java/com/epam/triangful/TriangleCalculationTest.java
@@ -1,9 +1,9 @@
-package com.labs.restservice;
+package com.epam.triangful;
 
-import com.labs.restservice.calculations.CalculationService;
-import com.labs.restservice.exception.ApiException.ApiRequestException;
-import com.labs.restservice.exception.InternalException.InternalArithmeticException;
-import com.labs.restservice.triangle.Triangle;
+import com.epam.triangful.calculations.CalculationService;
+import com.epam.triangful.exception.ApiException.ApiRequestException;
+import com.epam.triangful.exception.InternalException.InternalArithmeticException;
+import com.epam.triangful.triangle.Triangle;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Change packages names from `com.labs.restservice` to `com.epam.triangful`, so it looks more informative and beautiful. 